### PR TITLE
feat: MET-2497 add proper type to entity

### DIFF
--- a/src/utils/restructureData.util.ts
+++ b/src/utils/restructureData.util.ts
@@ -91,7 +91,6 @@ export const restructureData = (
           ...(entity as Entity),
           key: node.key,
           skey: node.skey,
-          type: node.type,
         };
       }
 


### PR DESCRIPTION
Previously by mistake I overwritten entity type with node type (which resulted in every entity having HTMLElement type). Now I fixed it so that entity will have proper type: image, div or input.